### PR TITLE
Support MAAS 2.7

### DIFF
--- a/create.sh
+++ b/create.sh
@@ -8,6 +8,7 @@ PROFILE=maas-profile.yaml
 : ${LP_KEYNAME:=undefined}
 : ${MAAS_CHANNEL:=2.7}
 : ${JUJU_CHANNEL:=2.9}
+: ${POSTGRESQL:=yes}
 
 debug=0
 refresh=0
@@ -179,13 +180,14 @@ if ! grep --quiet "$(cat ~/.ssh/id_rsa_maas-test.pub)" ~/.ssh/authorized_keys; t
 fi
 
 sed \
-    --expression "s:LP_KEYNAME:${LP_KEYNAME}:" \
-    --expression "s:MAAS_CHANNEL:${MAAS_CHANNEL}:" \
-    --expression "s:JUJU_CHANNEL:${JUJU_CHANNEL}:" \
-    --expression "s:VIRSH_USER:${USER}:" \
+    --expression "s:LP_KEYNAME:${LP_KEYNAME}:g" \
+    --expression "s:POSTGRESQL:${POSTGRESQL}:g" \
+    --expression "s:MAAS_CHANNEL:${MAAS_CHANNEL}:g" \
+    --expression "s:JUJU_CHANNEL:${JUJU_CHANNEL}:g" \
+    --expression "s:VIRSH_USER:${USER}:g" \
     maas-test-setup.sh > ${tempdir}/maas-test-setup.sh
 sed \
-    --expression "s:VIRSH_USER:${USER}:" \
+    --expression "s:VIRSH_USER:${USER}:g" \
     add-machine.sh > ${tempdir}/add-machine.sh
 sed \
     --expression "s:SSH_PUBLIC_KEY:$(cat ~/.ssh/id_rsa.pub):" \

--- a/user-data
+++ b/user-data
@@ -13,7 +13,12 @@ packages:
   - libvirt-clients
   - libvirt-daemon-system
   - python3-virtualenv
+  - systemd-journal-remote
   - virtinst
+  # Set up remote logging
+  # apt install --yes --no-install-recommends systemd-journal-remote
+  # systemctl start systemd-journal-remote
+  # systemctl enable systemd-journal-remote
 
 chpasswd:
   expire: False


### PR DESCRIPTION
The maas-test-db does not support MAAS versions < 2.8. We need to
install a regular postgresql database in this case.

Signed-off-by: Nicolas Bock <nicolas.bock@canonical.com>