### PR TITLE
Use local mirror for boot images

### DIFF
--- a/create.sh
+++ b/create.sh
@@ -46,6 +46,25 @@ upload_volume() {
 }
 
 refresh_cloud_image() {
+    echo "Refreshing image mirror"
+    local KEYRING_FILE=/usr/share/keyrings/ubuntu-cloudimage-keyring.gpg
+    local IMAGE_SRC=https://images.maas.io/ephemeral-v3/stable
+    local IMAGE_DIR=/var/www/html/maas/images/ephemeral-v3/stable
+
+    sudo sstream-mirror \
+        --keyring=$KEYRING_FILE \
+        $IMAGE_SRC \
+        $IMAGE_DIR \
+        'arch=amd64' \
+        'release~(xenial|bionic|focal)' \
+        --max=1 --progress
+    sudo sstream-mirror \
+        --keyring=$KEYRING_FILE \
+        $IMAGE_SRC \
+        $IMAGE_DIR \
+        'os~(grub*|pxelinux)' \
+        --max=1 --progress
+
     echo "Refreshing cloud images"
     for series in bionic focal; do
         image=${series}-server-cloudimg-amd64.img

--- a/maas-test-setup.sh
+++ b/maas-test-setup.sh
@@ -173,11 +173,16 @@ maas admin maas set-config name=curtin_verbose value=true
 maas admin maas set-config name=ntp_server value=ntp.ubuntu.com
 
 # Sync distros
-maas admin boot-source-selections create 1 os="ubuntu" release="xenial" \
+maas admin boot-sources create \
+    url=http://10.0.0.1:8000/maas/images/ephemeral-v3/stable \
+    keyring_filename=/usr/share/keyrings/ubuntu-cloudimage-keyring.gpg
+maas admin boot-source delete 1
+
+maas admin boot-source-selections create 2 os="ubuntu" release="xenial" \
     arches="amd64" subarches="*" labels="*" || :
-maas admin boot-source-selections create 1 os="ubuntu" release="bionic" \
+maas admin boot-source-selections create 2 os="ubuntu" release="bionic" \
     arches="amd64" subarches="*" labels="*" || :
-maas admin boot-source-selections create 1 os="ubuntu" release="focal" \
+maas admin boot-source-selections create 2 os="ubuntu" release="focal" \
     arches="amd64" subarches="*" labels="*" || :
 
 maas admin boot-sources read


### PR DESCRIPTION
The setup requires `simplestreams` and `apache2` to be installed on
the hypervisor. Also make sure that port `8000` is accessible from the
VM.

Signed-off-by: Nicolas Bock <nicolas.bock@canonical.com>