### PR TITLE
Remove mutmut cache in tox test

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -17,8 +17,11 @@ commands = mypy --install-types --non-interactive maaslab tests
 
 [testenv:mutmut]
 deps = mutmut
-whitelist_externals = bash
+whitelist_externals =
+    bash
+    rm
 commands =
+    rm --verbose --force .mutmut-cache
     -mutmut run --paths-to-mutate maaslab {posargs}
     mutmut result-ids survived
     mutmut results


### PR DESCRIPTION
Signed-off-by: Nicolas Bock <nicolas.bock@canonical.com>
