### PR TITLE
Add standalone script to start `maaslab`

### DIFF
--- a/maaslab/main.py
+++ b/maaslab/main.py
@@ -43,3 +43,7 @@ def main():
     else:
         raise Exception(f'[FIXME] cannot handle provider f{options.provider}')
     print(maas_server)  # pragma: no mutate
+
+
+if __name__ == '__main__':  # pragma: no mutate
+    main()

--- a/scripts/maaslab
+++ b/scripts/maaslab
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+export PYTHONPATH=$(realpath $(dirname $0)/..)
+
+python3 ${PYTHONPATH}/maaslab/main.py $@


### PR DESCRIPTION
This is useful while developing. The Python scripts do not have to be
built or installed to run the helper script.

Signed-off-by: Nicolas Bock <nicolas.bock@canonical.com>
