### PR TITLE
Make proxy optional

### DIFF
--- a/add-machine.sh
+++ b/add-machine.sh
@@ -83,7 +83,7 @@ fi
 VIRSH_IP=$(ip route show default | awk '{print $3}')
 
 virt-install \
-    --connect qemu+ssh://VIRSH_USER@${VIRSH_IP}/system \
+    --connect qemu+ssh://TEMPLATE_VIRSH_USER@${VIRSH_IP}/system \
     --name ${vm_id} \
     --memory ${memory} \
     --disk size=8 \
@@ -92,10 +92,10 @@ virt-install \
     --boot network \
     --noautoconsole
 
-ip=$(virsh --connect qemu+ssh://VIRSH_USER@${VIRSH_IP}/system \
+ip=$(virsh --connect qemu+ssh://TEMPLATE_VIRSH_USER@${VIRSH_IP}/system \
     domifaddr maas-server | grep ipv4 | awk '{print $4}' | awk -F/ '{print $1}')
 mac=$(xmllint --xpath "//source[@network='maas-oam-net']/../mac/@address" \
-    <(virsh --connect qemu+ssh://VIRSH_USER@${VIRSH_IP}/system dumpxml ${vm_id}) \
+    <(virsh --connect qemu+ssh://TEMPLATE_VIRSH_USER@${VIRSH_IP}/system dumpxml ${vm_id}) \
     | awk -F= '{print $2}' | tr --delete '"')
 
 maas admin machines create \
@@ -103,4 +103,4 @@ maas admin machines create \
     mac_addresses=${mac} \
     power_type=virsh \
     power_parameters_power_id=${vm_id} \
-    power_parameters_power_address=qemu+ssh://VIRSH_USER@${VIRSH_IP}/system
+    power_parameters_power_address=qemu+ssh://TEMPLATE_VIRSH_USER@${VIRSH_IP}/system

--- a/create.sh
+++ b/create.sh
@@ -294,15 +294,15 @@ if ! grep --quiet "$(cat ~/.ssh/id_rsa_maas-test.pub)" ~/.ssh/authorized_keys; t
 fi
 
 sed \
-    --expression "s:LP_KEYNAME:${lp_keyname}:g" \
-    --expression "s:POSTGRESQL:$( ((postgresql == 1)) && echo "yes" ):g" \
-    --expression "s:MAAS_CHANNEL:${maas_channel}:g" \
-    --expression "s:JUJU_CHANNEL:${juju_channel}:g" \
-    --expression "s:VIRSH_USER:${USER}:g" \
-    --expression "s:MAAS_FROM_DEB:$( ((maas_deb == 1)) && echo "yes"):" \
-    --expression "s:FABRIC_NAMES:${!networks[*]}:" \
-    --expression "s:FABRIC_CIDRS:${networks[*]}:" \
-    --expression "s:DEFAULT_SERIES:${series}:" \
+    --expression "s:TEMPLATE_LP_KEYNAME:${lp_keyname}:g" \
+    --expression "s:TEMPLATE_POSTGRESQL:$( ((postgresql == 1)) && echo "yes" ):g" \
+    --expression "s:TEMPLATE_MAAS_CHANNEL:${maas_channel}:g" \
+    --expression "s:TEMPLATE_JUJU_CHANNEL:${juju_channel}:g" \
+    --expression "s:TEMPLATE_VIRSH_USER:${USER}:g" \
+    --expression "s:TEMPLATE_MAAS_FROM_DEB:$( ((maas_deb == 1)) && echo "yes"):" \
+    --expression "s:TEMPLATE_FABRIC_NAMES:${!networks[*]}:" \
+    --expression "s:TEMPLATE_FABRIC_CIDRS:${networks[*]}:" \
+    --expression "s:TEMPLATE_DEFAULT_SERIES:${series}:" \
     maas-test-setup-new.sh > "${tempdir}"/maas-test-setup.sh
 sed \
     --expression "s:VIRSH_USER:${USER}:g" \

--- a/create.sh
+++ b/create.sh
@@ -376,8 +376,10 @@ if (( console == 1 )); then
 fi
 
 # Deleting tempdirs
-rm -rf "${ci_tempdir}"
-rm -rf "${tempdir}"
+if [[ ${debug} = 0 ]]; then
+    rm -rf "${ci_tempdir}"
+    rm -rf "${tempdir}"
+fi
 
 MAAS_IP=$(get_host ${MANAGEMENT_NET} 1)
 echo "MAAS server can be reached at ${MAAS_IP}"

--- a/create.sh
+++ b/create.sh
@@ -305,10 +305,10 @@ sed \
     --expression "s:TEMPLATE_DEFAULT_SERIES:${series}:" \
     maas-test-setup-new.sh > "${tempdir}"/maas-test-setup.sh
 sed \
-    --expression "s:VIRSH_USER:${USER}:g" \
+    --expression "s:TEMPLATE_VIRSH_USER:${USER}:g" \
     add-machine.sh > "${tempdir}"/add-machine.sh
 sed \
-    --expression "s:SSH_PUBLIC_KEY:$(cat ~/.ssh/id_rsa.pub):" \
+    --expression "s:TEMPLATE_SSH_PUBLIC_KEY:$(cat ~/.ssh/id_rsa.pub):" \
     meta-data > "${ci_tempdir}"/meta-data
 if [[ -f ~/.vimrc ]]; then
     cp ~/.vimrc "${tempdir}"

--- a/create.sh
+++ b/create.sh
@@ -303,7 +303,7 @@ sed \
     --expression "s:TEMPLATE_FABRIC_NAMES:${!networks[*]}:" \
     --expression "s:TEMPLATE_FABRIC_CIDRS:${networks[*]}:" \
     --expression "s:TEMPLATE_DEFAULT_SERIES:${series}:" \
-    --expression "s:TEMPLATE_HTTP_PROXY:${http_proxy}:" \
+    --expression "s;TEMPLATE_HTTP_PROXY;${http_proxy};" \
     maas-test-setup-new.sh > "${tempdir}"/maas-test-setup.sh
 sed \
     --expression "s:TEMPLATE_VIRSH_USER:${USER}:g" \

--- a/create.sh
+++ b/create.sh
@@ -335,16 +335,16 @@ awk -v http_proxy="${snap_http_proxy}" \
     > ${tempdir}/commissioning-snap-proxy.sh
 
 sed \
-    --expression "s:MAAS_SSH_PRIVATE_KEY:$(base64 --wrap 0 ~/.ssh/id_rsa_maas-test):" \
-    --expression "s:MAAS_SSH_PUBLIC_KEY:$(base64 --wrap 0 ~/.ssh/id_rsa_maas-test.pub):" \
-    --expression "s:SSH_PUBLIC_KEY:$(cat ~/.ssh/id_rsa.pub):" \
-    --expression "s:SETUP_SCRIPT:$(base64 --wrap 0 ${tempdir}/maas-test-setup.sh):" \
-    --expression "s:ADD_MACHINE_SCRIPT:$(base64 --wrap 0 ${tempdir}/add-machine.sh):" \
-    --expression "s:VIMRC:$(base64 --wrap 0 ${tempdir}/.vimrc):" \
-    --expression "s:COMMISSIONING_SNAP_PROXY:$(base64 --wrap 0 ${tempdir}/commissioning-snap-proxy.sh):" \
-    --expression "s:SYNC:${sync}:" \
+    --expression "s:TEMPLATE_MAAS_SSH_PRIVATE_KEY:$(base64 --wrap 0 ~/.ssh/id_rsa_maas-test):" \
+    --expression "s:TEMPLATE_MAAS_SSH_PUBLIC_KEY:$(base64 --wrap 0 ~/.ssh/id_rsa_maas-test.pub):" \
+    --expression "s:TEMPLATE_SSH_PUBLIC_KEY:$(cat ~/.ssh/id_rsa.pub):" \
+    --expression "s:TEMPLATE_SETUP_SCRIPT:$(base64 --wrap 0 ${tempdir}/maas-test-setup.sh):" \
+    --expression "s:TEMPLATE_ADD_MACHINE_SCRIPT:$(base64 --wrap 0 ${tempdir}/add-machine.sh):" \
+    --expression "s:TEMPLATE_VIMRC:$(base64 --wrap 0 ${tempdir}/.vimrc):" \
+    --expression "s:TEMPLATE_COMMISSIONING_SNAP_PROXY:$(base64 --wrap 0 ${tempdir}/commissioning-snap-proxy.sh):" \
+    --expression "s:TEMPLATE_SYNC:${sync}:" \
     user-data |
-    awk -v p="${apt_proxy}" '{ gsub(/APT_PROXY_SETTING/, p) } { print($0) }' \
+    awk -v p="${apt_proxy}" '{ gsub(/TEMPLATE_APT_PROXY_SETTING/, p) } { print($0) }' \
     > "${ci_tempdir}"/user-data
 
 echo "Creating config drive"

--- a/create.sh
+++ b/create.sh
@@ -133,9 +133,9 @@ create_network() {
     if [[ ${net_name} =~ oam ]]; then
         template=maas-net-nat.xml
     fi
-    virsh net-define <(sed --expression "s:NAME:${net_name}:" \
-        --expression "s/NETMASK/$(get_netmask ${net_cidr})/" \
-        --expression "s/NETWORK4/$(get_gateway ${net_cidr})/" \
+    virsh net-define <(sed --expression "s:TEMPLATE_NET_NAME:${net_name}:" \
+        --expression "s/TEMPLATE_NETMASK4/$(get_netmask ${net_cidr})/" \
+        --expression "s/TEMPLATE_NETWORK4/$(get_gateway ${net_cidr})/" \
         ${template})
 
     virsh net-autostart ${net_name}

--- a/create.sh
+++ b/create.sh
@@ -144,17 +144,17 @@ create_network() {
         ${network_options[@]}
         --network network=${net_name},model=virtio,address.type="pci",address.slot=$((slot_offset)),mac.address=${mac_address}
     )
-    sed --expression "s:DEVICE:ens${slot_offset}:" \
-        --expression "s:DHCP:false:" \
-        --expression "s/MACADDRESS/${mac_address}/" \
-        --expression "s:ADDRESS:$(get_host ${net_cidr} 1)/$(get_prefix ${net_cidr}):" \
+    sed --expression "s:TEMPLATE_DEVICE:ens${slot_offset}:" \
+        --expression "s:TEMPLATE_DHCP4:false:" \
+        --expression "s/TEMPLATE_MACADDRESS/${mac_address}/" \
+        --expression "s:TEMPLATE_ADDRESS4:$(get_host ${net_cidr} 1)/$(get_prefix ${net_cidr}):" \
         --expression $( [[ ${net_cidr} == ${MANAGEMENT_NET} ]] \
-        && echo "s:SUBNET_GATEWAY:$(get_gateway ${net_cidr}):" \
+        && echo "s:TEMPLATE_SUBNET_GATEWAY4:$(get_gateway ${net_cidr}):" \
         || echo '/gateway4.*$/d') \
         --expression $( [[ ${net_cidr} == ${MANAGEMENT_NET} ]] \
-        && echo "s/NAMESERVERS/[172.18.0.1]/" \
-        || echo '/nameservers.*$/d --expression /^.*NAMESERVERS.*/d') \
-        --expression "s:DEFAULT_GATEWAY:172.18.0.1:" \
+        && echo "s/TEMPLATE_NAMESERVERS/[172.18.0.1]/" \
+        || echo '/nameservers.*$/d --expression /^.*TEMPLATE_NAMESERVERS.*/d') \
+        --expression "s:TEMPLATE_DEFAULT_GATEWAY4:172.18.0.1:" \
         network-config.yaml > "${tempdir}"/new-interface.yaml
     yq eval-all --inplace \
         'select(fileIndex == 0) * select(fileIndex == 1)' \

--- a/maas-net-nat.xml
+++ b/maas-net-nat.xml
@@ -1,10 +1,10 @@
 <network>
-  <name>NAME</name>
+  <name>TEMPLATE_NET_NAME</name>
   <forward mode='nat'>
     <nat>
       <port start='1024' end='65535'/>
     </nat>
   </forward>
-  <ip address='NETWORK4' netmask='NETMASK'/>
+  <ip address='TEMPLATE_NETWORK4' netmask='TEMPLATE_NETMASK4'/>
   <!-- <ip family='ipv6' address='NETWORK6' prefix='64'/> -->
 </network>

--- a/maas-net-route.xml
+++ b/maas-net-route.xml
@@ -1,6 +1,6 @@
 <network>
-  <name>NAME</name>
+  <name>TEMPLATE_NET_NAME</name>
   <forward mode='route'/>
-  <ip address='NETWORK4' netmask='NETMASK'/>
+  <ip address='TEMPLATE_NETWORK4' netmask='TEMPLATE_NETMASK4'/>
   <!-- <ip family='ipv6' address='NETWORK6' prefix='64'/> -->
 </network>

--- a/maas-test-setup-new.sh
+++ b/maas-test-setup-new.sh
@@ -35,17 +35,17 @@ while ! ping -c 1 ${PROXY_ADDRESS}; do
     sleep 1
 done
 
-snap install --channel JUJU_CHANNEL --classic juju
+snap install --channel TEMPLATE_JUJU_CHANNEL --classic juju
 snap install openstackclients
 
 # Remove virsh networks to prevent MAAS from failing to start during DHCP probe.
 virsh net-destroy default || echo "ignoring"
 virsh net-autostart --disable default || echo "ignoring"
 
-apt-add-repository --yes ppa:maas/MAAS_CHANNEL
+apt-add-repository --yes ppa:maas/TEMPLATE_MAAS_CHANNEL
 apt-get update
 
-if [[ MAAS_FROM_DEB == yes ]]; then
+if [[ TEMPLATE_MAAS_FROM_DEB == yes ]]; then
     DEBIAN_FRONTEND=noninteractive apt-get install --yes --no-install-recommends maas
     maas_db_password=$(sudo grep dbc_dbpass= /etc/dbconfig-common/maas-region-controller.conf | sed -e "s:^.*'\([^']*\)':\1:")
 else
@@ -62,7 +62,7 @@ if ! maas admin account list-authorisation-tokens; then
         --username ubuntu \
         --password ubuntu \
         --email maastest@virtual \
-        $([[ "LP_KEYNAME" != undefined ]] && echo "--ssh-import lp:LP_KEYNAME")
+        $([[ "TEMPLATE_LP_KEYNAME" != undefined ]] && echo "--ssh-import lp:TEMPLATE_LP_KEYNAME")
 fi
 
 maas apikey --username ubuntu > /root/ubuntu-api-key
@@ -76,7 +76,7 @@ cat <<- EOF > ~ubuntu/juju/bootstrap.sh
 declare -a model_config=()
 declare -a model_defaults=(
     image-stream=released
-    default-series=DEFAULT_SERIES
+    default-series=TEMPLATE_DEFAULT_SERIES
     no-proxy=127.0.0.1,localhost,::1,172.18.0.0/16
     apt-http-proxy=${PROXY}
     apt-https-proxy=${PROXY}
@@ -169,15 +169,15 @@ for series in focal bionic; do
         arches="amd64" subarches="*" labels="*" || :
 done
 
-while ! maas admin maas set-config name=commissioning_distro_series value=DEFAULT_SERIES; do
+while ! maas admin maas set-config name=commissioning_distro_series value=TEMPLATE_DEFAULT_SERIES; do
     sleep 10
 done
-while ! maas admin maas set-config name=default_distro_series value=DEFAULT_SERIES; do
+while ! maas admin maas set-config name=default_distro_series value=TEMPLATE_DEFAULT_SERIES; do
     sleep 10
 done
 
-declare -a fabric_names=( FABRIC_NAMES )
-declare -a fabric_cidrs=( FABRIC_CIDRS )
+declare -a fabric_names=( TEMPLATE_FABRIC_NAMES )
+declare -a fabric_cidrs=( TEMPLATE_FABRIC_CIDRS )
 declare -A fabrics=()
 declare oam_network_name
 
@@ -245,7 +245,7 @@ maas admin vlan update "${fabric}" 0 dhcp_on=true \
 # Copy ssh keys to MAAS controller so that it can talk to the libvirt daemon on
 # the hypervisor.
 declare ssh_root_dir
-if [[ "MAAS_FROM_DEB" == yes ]]; then
+if [[ "TEMPLATE_MAAS_FROM_DEB" == yes ]]; then
     ssh_root_dir=/var/lib/maas/.ssh
 else
     ssh_root_dir=/var/snap/maas/current/root/.ssh

--- a/meta-data
+++ b/meta-data
@@ -1,7 +1,7 @@
 instance-id: id-12345
 local-hostname: maas-test
 public-keys:
-  - SSH_PUBLIC_KEY
+  - TEMPLATE_SSH_PUBLIC_KEY
 
 # Local Variables:
 # mode: yaml

--- a/network-config.yaml
+++ b/network-config.yaml
@@ -1,15 +1,15 @@
 version: 2
 ethernets:
-  DEVICE:
+  TEMPLATE_DEVICE:
     match:
       # name: "DEVICE"
-      macaddress: "MACADDRESS"
-    dhcp4: DHCP
-    addresses: [ADDRESS]
+      macaddress: "TEMPLATE_MACADDRESS"
+    dhcp4: TEMPLATE_DHCP4
+    addresses: [TEMPLATE_ADDRESS4]
     mtu: 1500
-    gateway4: SUBNET_GATEWAY
+    gateway4: TEMPLATE_SUBNET_GATEWAY4
     nameservers:
-      addresses: NAMESERVERS
+      addresses: TEMPLATE_NAMESERVERS
     routes:
       - to: 0.0.0.0
-        via: DEFAULT_GATEWAY
+        via: TEMPLATE_DEFAULT_GATEWAY4

--- a/user-data
+++ b/user-data
@@ -2,12 +2,12 @@
 disable_root: False
 ssh_pwauth: True
 ssh_authorized_keys:
-  - SSH_PUBLIC_KEY
+  - TEMPLATE_SSH_PUBLIC_KEY
 package_update: True
 package_upgrade: True
 package_reboot_if_required: True
 
-APT_PROXY_SETTING
+TEMPLATE_APT_PROXY_SETTING
 
 packages:
   - jq
@@ -30,32 +30,32 @@ chpasswd:
 
 write_files:
 - encoding: b64
-  content: SETUP_SCRIPT
+  content: TEMPLATE_SETUP_SCRIPT
   path: /usr/bin/maas-test-setup.sh
   permissions: '0755'
 - encoding: b64
-  content: ADD_MACHINE_SCRIPT
+  content: TEMPLATE_ADD_MACHINE_SCRIPT
   path: /usr/bin/add-machine.sh
   permissions: '0755'
 - encoding: b64
-  content: MAAS_SSH_PRIVATE_KEY
+  content: TEMPLATE_MAAS_SSH_PRIVATE_KEY
   path: /root/.ssh/id_rsa
   permissions: '0600'
 - encoding: b64
-  content: MAAS_SSH_PUBLIC_KEY
+  content: TEMPLATE_MAAS_SSH_PUBLIC_KEY
   path: /root/.ssh/id_rsa.pub
   permissions: '0644'
 - encoding: b64
-  content: VIMRC
+  content: TEMPLATE_VIMRC
   path: /etc/vim/vimrc.local
   permissions: '0644'
 - encoding: b64
-  content: COMMISSIONING_SNAP_PROXY
+  content: TEMPLATE_COMMISSIONING_SNAP_PROXY
   path: /root/99-commissioning-snap-proxy.sh
   permissions: '0755'
 
 runcmd:
-  - [maas-test-setup.sh, --sync, "SYNC"]
+  - [maas-test-setup.sh, --sync, "TEMPLATE_SYNC"]
 
 final_message: The MAAS server is ready
 


### PR DESCRIPTION
This PR finishes the implementation of the --http-proxy option of create.sh. By default no proxy will be configured unless this option is used. Previous hard-coding of proxy is removed. 

There are 3 main parts to the commit.

The first part removes the deletion of tmp dirs when the --debug option is used. This helps with debugging, including the implementation of this PR.

The second part is a series of commits that replace all templated strings in template files with equivalents that have a prefix of "TEMPLATE_". This helps distinguishing cases where other ALL_CAPS strings are not template strings. This is divided into 5 commits based on the template files changed:
Add TEMPLATE_ prefix 1: create.sh maas-net-nat.xml maas-net-route.xml
Add TEMPLATE_ prefix 2: create.sh network-config.yaml
Add TEMPLATE_ prefix 3: create.sh maas-test-setup-new.sh
Add TEMPLATE_ prefix 4: create.sh add-machine.sh meta-data
Add TEMPLATE_ prefix 5: create.sh user-data
There are some additional minor changes related to the TEMPLATE_ prefix.

The third part is the actual change that make the http_proxy option.

Note this has not been tested for the case of having an http proxy, but it does get to the point where it pings forever until one is available at the the given address. This was how the create.sh script worked before the change when the hard-coded proxy was not resolvable/available.