### PR TITLE
Add support for non-stable juju channel risk

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -14,7 +14,6 @@ jobs:
     strategy:
       matrix:
         python:
-          - 2.7
           - 3.6
           - 3.7
           - 3.8

--- a/create.sh
+++ b/create.sh
@@ -177,6 +177,7 @@ Usage:
 -s | --sync          Sync MAAS images (default is not to)
 -m | --maas-channel  The MAAS channel (default: ${maas_channel})
 -j | --juju-channel  The juju channel (default: ${juju_channel})
+                     Can also specify risk-level, e.g. 3.1/beta
 -k | --lp-keyname    The launchpad key name to import (default: ${lp_keyname})
 -p | --postgresql    Use postgresql package instead of maas-test-db (default: ${postgresql})
 --maas-deb           Install MAAS from deb (not snap)
@@ -240,6 +241,17 @@ if [[ ${debug} = 1 ]]; then
     echo "setting debug output"
     set -x
     PS4='+(${BASH_SOURCE##*/}:${LINENO}) ${FUNCNAME[0]:+${FUNCNAME[0]}(): }'
+fi
+
+if echo $juju_channel | grep -q /; then
+    juju_track=$( echo $juju_channel | awk -F/ '{print $1}')
+    juju_risk=$( echo $juju_channel | awk -F/ '{print $2}')
+    juju_branch=$( echo $juju_channel | awk -F/ '{print $3}')
+else
+    juju_track=$juju_channel
+    juju_risk=stable
+    juju_branch=
+    juju_channel="$juju_track/$juju_risk"
 fi
 
 if [[ ${refresh} = 1 ]]; then

--- a/maas-test-setup-new.sh
+++ b/maas-test-setup-new.sh
@@ -213,7 +213,10 @@ for i in $(seq 0 $(( ${#fabric_names[@]} - 1 ))); do
         oam_network_name=${fabric_name}
     fi
     space_id=$(maas admin spaces create name="${fabric_name}" | jq '.id')
-    fabric_id=$(maas admin spaces read | jq --arg cidr ${fabric_cidr} '.[].subnets[] | select(.cidr == $cidr) | .vlan.fabric_id')
+    fabric_id=''
+    while [[ -z "$fabric_id" ]]; do
+        fabric_id=$(maas admin spaces read | jq --arg cidr ${fabric_cidr} '.[].subnets[] | select(.cidr == $cidr) | .vlan.fabric_id')
+    done
     maas admin fabric update "${fabric_id}" name="${fabric_name}"
     maas admin vlan update "${fabric_id}" 0 space="${fabric_name}"
 done


### PR DESCRIPTION
After testing then changes with '--juju-channel=3.2/beta' successfully I tested with '--juju-channel=3.1' which failed due to a race condition between calls to 'maas admin spaces create' and 'maas admin spaces read'. This is the reason for the changes to maas-test-setup-new.sh.