### PR TITLE
Do not fail fast in tests

### DIFF
--- a/.github/workflows/build_and_test.yaml
+++ b/.github/workflows/build_and_test.yaml
@@ -12,6 +12,7 @@ on:
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
         python:
           - 3.6


### PR DESCRIPTION
Since we require only Python 3.11 we can't fail fast in the Python
version matrix. This might cause a failure in another Python version to
cancel the Python 3.11 test.

Signed-off-by: Nicolas Bock <nicolas.bock@canonical.com>
