### PR TITLE
Replace deprecated `whitelist_externals`

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ commands = mypy --install-types --non-interactive maaslab tests
 
 [testenv:mutmut]
 deps = mutmut
-whitelist_externals =
+allowlist_externals =
     bash
     rm
 commands =


### PR DESCRIPTION
Signed-off-by: Nicolas Bock <nicolas.bock@canonical.com>
