### PR TITLE
Make names & networks variable to make re-entrant

### DIFF
--- a/maas-test-setup-new.sh
+++ b/maas-test-setup-new.sh
@@ -87,7 +87,7 @@ if [[ -n "$PROXY" ]]; then
     declare -a model_defaults=(
         image-stream=released
         default-series=TEMPLATE_DEFAULT_SERIES
-        no-proxy=127.0.0.1,localhost,::1,172.18.0.0/16
+        no-proxy=127.0.0.1,localhost,::1,TEMPLATE_NETWORK_PREFIX.0.0/16
         apt-http-proxy=${PROXY}
         apt-https-proxy=${PROXY}
         snap-http-proxy=${PROXY}
@@ -99,7 +99,7 @@ else
     declare -a model_defaults=(
         image-stream=released
         default-series=TEMPLATE_DEFAULT_SERIES
-        no-proxy=127.0.0.1,localhost,::1,172.18.0.0/16
+        no-proxy=127.0.0.1,localhost,::1,TEMPLATE_NETWORK_PREFIX.0.0/16
     )
 fi
 
@@ -124,7 +124,7 @@ Host *
 Host 192.168.0.200
     IdentityFile ~/.ssh/id_rsa
 
-Host 172.18.*.*
+Host TEMPLATE_NETWORK_PREFIX.*.*
     IdentityFile ~/testkey.priv
 EOF
 chown -R ubuntu: ~ubuntu/.ssh/config
@@ -137,7 +137,7 @@ clouds:
   mymaas:
     type: maas
     auth-types: [ oauth1 ]
-    endpoint: http://172.18.0.2:5240/MAAS/
+    endpoint: http://TEMPLATE_NETWORK_PREFIX.0.2:5240/MAAS/
 
 __EOF__
 cat << __EOF__ > /tmp/mymaas_credentials.txt
@@ -223,7 +223,7 @@ done
 
 default_gateway=$(get_host ${fabrics[${oam_network_name}]} 1)
 
-ab=172.18
+ab=TEMPLATE_NETWORK_PREFIX
 gw=${ab}.0.1
 cidr=${ab}.0.0/24
 subnet_id=$(maas admin subnets read | jq -r ".[] | select(.cidr==\"${cidr}\").id")

--- a/meta-data
+++ b/meta-data
@@ -1,5 +1,5 @@
 instance-id: id-12345
-local-hostname: maas-test
+local-hostname: TEMPLATE_VM_NAME
 public-keys:
   - TEMPLATE_SSH_PUBLIC_KEY
 


### PR DESCRIPTION
Add variable NAME_PREFIX defaulting to 'maas-test' that can be overidden by setting it as an environment variable.

Add -1 on end of maas server name to allow for future clustering of maas servers.

Use NAME_PREFIX for maas server name, which adds '-test' to the default which now ends up being maas-test-server-1. If setting NAME_PREFIX to maas-1 then server name would be maas-1-server-1.

Use NAME_PREFIX for network name prefixes as well. Also shorten distinct parts of network names to consistent 3 letters because hey, I like it when the same parts of names line up:
 - maas-test-oam-net
 - maas-test-adm-net
 - maas-test-int-net
 - maas-test-pub-net
 - maas-test-stg-net or
 - maas-1-oam-net
 - maas-1-adm-net
 - maas-1-int-net
 - maas-1-pub-net
 - maas-1-stg-net

Replace hard-coded first two octets of networks with NETWORK_PREFIX which defaults to 172.18.

Remove '-test' from ssh key file names leaving them hard-coded with generic '_maas' suffix. We could have also mad the suffix variable but this means the config inside the maas server is consistent.

Replace appropriate instances of 'maas-test' with TEMPLATE_* variables.